### PR TITLE
integrate alive_progress for loading state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ openai = "^1.61.1"
 boto3 = "^1.36.14"
 pytest-mock = "^3.14.0"
 mocker = "^1.1.1"
+alive-progress = "^3.1.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"

--- a/ragxo/client.py
+++ b/ragxo/client.py
@@ -11,6 +11,7 @@ import tempfile
 from botocore.exceptions import ClientError
 import openai
 from openai import ChatCompletion
+from ragxo.utils import with_loading
 
 logger = logging.getLogger(__name__)
 
@@ -140,6 +141,7 @@ class Ragxo:
         self.presence_penalty = presence_penalty
         return self
     
+    @with_loading("Indexing documents")
     def index(self, data: list[Document]) -> Self:
         """
         Index documents into the vector database.
@@ -210,6 +212,7 @@ class Ragxo:
             output_fields=output_fields
         )
 
+    @with_loading("Exporting Ragxo instance")
     def export(self, destination: str, s3_bucket: str = None) -> Self:
         """
         Export the Ragx instance to either local filesystem or S3.

--- a/ragxo/utils.py
+++ b/ragxo/utils.py
@@ -1,0 +1,21 @@
+import functools
+from alive_progress import alive_bar
+
+
+def with_loading(title: str):
+    """
+    Decorator to add loading animation to methods.
+    
+    Args:
+        title (str): Title to display during loading
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            with alive_bar(title=title, bar=None, stats=False) as bar:
+                result = func(self, *args, **kwargs)
+                bar()
+            return result
+        return wrapper
+    return decorator


### PR DESCRIPTION
@mohamedfawzy96 really cool project, i think it's a crucial piece for RAG users

This PR is NIT:
- The motive behind it when i was using `Ragxo` i found some latency without any feedback
- This PR just adds a loading state using [alive_progress](https://github.com/rsalmei/alive-progress#styles)

Logic inside PR
1. added `alive_progress` inside `pyproject.toml`
2. added a `utils.py` file which lives inside a decorator to handle loading state
3. added the `with_loading` decorator to both `index` and `export` methods

![ragxo](https://github.com/user-attachments/assets/365c954d-80f7-48b6-a533-0f0921b8595a)

This PR can serve as a future reference if you want to add any loading states.





